### PR TITLE
Fix searches that contain certain special symbols.

### DIFF
--- a/header.php
+++ b/header.php
@@ -62,7 +62,7 @@
 			{
 				e.preventDefault();
 				var q = document.getElementById('q').value;
-				window.location.href = "<?= LIBRIVOX_CATALOG_SEARCH;  ?>/q/" + q;
+				window.location.href = "<?= LIBRIVOX_CATALOG_SEARCH;  ?>/?search_form=get_results&q=" + encodeURIComponent(q);
 			}
 			
 		</script>


### PR DESCRIPTION
When performing a search from the home page it was encoding the search
query into the URL path in the form of "search/q/{query}". But this fails
for many different symbols. Even if you try to URI encode the query a "/"
will still break it. This commit changes the URL to be
"search?search_form=get_results&q={query}" and URI encodes the query. This
seems to work fine for every possible query with special symbols I could
think of. The catalog code also had a similar bug and another issue that
broke some special symbols.