### PR TITLE
Remove Google Analytics

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -80,32 +80,6 @@ function librivox_scripts() {
 
 add_action( 'wp_enqueue_scripts', 'librivox_scripts' );
 
-
-/***************************************************************
-*
-* Google Analytics code
-*
-***************************************************************/
-
-function add_googleanalytics() { ?>
-	
-	<script type="text/javascript">
-
-		var _gaq = _gaq || [];
-		_gaq.push(['_setAccount', 'UA-1429228-8']);
-		_gaq.push(['_trackPageview']);
-		
-		(function() {
-		var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-		ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-		var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-		})();
-
-	</script>
-
-<?php } 
-add_action('wp_head', 'add_googleanalytics');
-
 /***************************************************************
 *
 * Register widgetized area and update sidebar with default widgets


### PR DESCRIPTION
We've had some users complain about the Ghostery extension flagging
these. As far as we know, they're unused, so remove them.

This is the sister commit to
https://github.com/LibriVox/librivox-catalog/pull/198
