### PR TITLE
Fix duplicated page titles

### DIFF
--- a/header.php
+++ b/header.php
@@ -8,7 +8,7 @@
 <head profile="http://gmpg.org/xfn/11">
 <meta http-equiv="Content-Type" content="<?php bloginfo('html_type'); ?>; charset=<?php bloginfo('charset'); ?>" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title><?php wp_title('|', true, 'right'); ?> <?php bloginfo('name'); ?> <?php if ( !wp_title('', true, 'left') ); { ?> | <?php bloginfo('description'); ?> <?php } ?></title>
+<title><?php wp_title('|', true, 'right'); ?> <?php bloginfo('name'); ?> <?php if ( !wp_title('', false, 'left') ) { ?> | <?php bloginfo('description'); ?> <?php } ?></title>
 
 <link rel="shortcut icon" href="<?php echo get_stylesheet_directory_uri(); ?>/favicon.ico" />
 <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->


### PR DESCRIPTION
Looks like `wp_title()` was called with the wrong argument #2, 'display': we don't want it to show the page title, we want it to _return_ the title if there is one.

Where there is no wp_title (i.e., on the home page), we default to showing the blog name and description:
`LibriVox | free public domain audiobooks`

Where there is a title set, we now show it only once, followed by blog name: `Sample Page | LibriVox`